### PR TITLE
Bug/1 kopi status config file

### DIFF
--- a/Kopi.Community.cli/Program.cs
+++ b/Kopi.Community.cli/Program.cs
@@ -320,14 +320,6 @@ internal class Program
     /// </summary>
     private static async Task RunKopiStatus()
     {
-		// var config = await ConfigLoader(null);
-		// if (config is null)
-		// {
-		// 	Msg.Write(MessageType.Error, "Failed to load configuration. Exiting.");
-		// 	Environment.Exit(1);
-		// 	return; // Necessary for nullable analysis
-		// }
-
 		var allContainers = await DockerService.GetAllContainersStatus();
 
         Msg.Write(MessageType.Info, "Kopi Docker Containers Status:");


### PR DESCRIPTION
I had left in some code that checked for a config file but it wasn't necessary as "status" checks all kopi docker instances and does not require a specific config file to exist.
It wouldn't go beyond the failure of the config file.

I've removed the code and it works fine now