### PR TITLE
DB creation order fix - Indexes added before FKs

### DIFF
--- a/Kopi.Core/Services/SQLServer/Target/TargetDbOrchestratorService.cs
+++ b/Kopi.Core/Services/SQLServer/Target/TargetDbOrchestratorService.cs
@@ -46,10 +46,10 @@ public class TargetDbOrchestratorService(
         await CreateTargetDatabaseFunctions(sourceDbData, targetDbConnectionString);
         await CreateTargetDatabaseUDFs(udfCreationScript, targetDbConnectionString);
         await CreateTargetDatabaseTables(tableCreationScript, targetDbConnectionString);
-        await CreateTargetDatabaseConstraints(sourceDbData, targetDbConnectionString);
         await CreateTargetDatabasePKs(primaryKeyCreationScript, targetDbConnectionString);
-        await CreateTargetDatabaseRelationships(relationshipCreationScript, targetDbConnectionString);
         await CreateTargetDatabaseIndexes(indexCreationScript, targetDbConnectionString);
+        await CreateTargetDatabaseConstraints(sourceDbData, targetDbConnectionString);
+        await CreateTargetDatabaseRelationships(relationshipCreationScript, targetDbConnectionString);
 
         var generatedData = await dataOrchestratorService.OrchestrateDataGeneration();
         var dataInsertionService = new DataInsertionService();


### PR DESCRIPTION
Indexes were being created too late so that when FK's were being created, there were missing indexes and referential integrity kicks in.

The fix was to change the order and make sure indexes exist first.