### PR TITLE
Updated .csproj files to remove hardcoded versions. 

### DIFF
--- a/Kopi.Community.cli/Kopi.Community.cli.csproj
+++ b/Kopi.Community.cli/Kopi.Community.cli.csproj
@@ -6,7 +6,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>Kopi</AssemblyName>
-        <AssemblyVersion>0.1.81</AssemblyVersion>
         <PackageId>Kopi</PackageId>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>kopi</ToolCommandName>

--- a/Kopi.Core/Kopi.Core.csproj
+++ b/Kopi.Core/Kopi.Core.csproj
@@ -4,10 +4,8 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
+        <AssemblyName>Kopi.Core</AssemblyName>
         <PackageId>Kopi.Core</PackageId>
-
-        <Version>0.1.81</Version>
 
         <Authors>Kopi Inc.</Authors>
         <Company>Kopi Inc.</Company>


### PR DESCRIPTION
Also added assemblyname to kopi.core

Hardcoded version strings were added to the .csproj files. This meant that they would always be there no matter what the build did. I've removed them to let the build add them instead
