### PR TITLE
Removed code from the decimal generator for the money datatype

### DIFF
--- a/Kopi.Core/Services/Common/DataGeneration/Generators/CommunityDefaultDecimalGenerator.cs
+++ b/Kopi.Core/Services/Common/DataGeneration/Generators/CommunityDefaultDecimalGenerator.cs
@@ -48,18 +48,6 @@ public class CommunityDefaultDecimalGenerator : IDataGenerator
             }
             return result;
         }
-        else if (dataType == "money" || dataType == "smallmoney")
-        {
-            var result = new List<object?>();
-            for (var i = 0; i < count; i++)
-            {
-                var value = (decimal)(Random.Shared.NextDouble() * (Random.Shared.Next(0, 2) == 0 ? -1 : 1) * (double)92233720368547758.07m);
-                value = Math.Round(value, 4);
-                result.Add(value);
-            }
-            return result;
-        }
-        
         
         
         throw new InvalidOperationException($"CommunityDefaultDecimalGenerator cannot generate data for column with data type: {column.DataType}");

--- a/Kopi.Core/Services/SQLServer/Source/SourceDbTableService.cs
+++ b/Kopi.Core/Services/SQLServer/Source/SourceDbTableService.cs
@@ -71,10 +71,7 @@ public class SourceDbTableService
             OBJECT_DEFINITION(dc.object_id) AS DefaultDefinition,
             dc.name AS DefaultConstraintName,
             ty.is_user_defined AS IsUserDefinedType,
-            cc.is_persisted AS IsPersisted,
-            
-            -- === THIS IS THE NEW, SAFE WAY TO CHECK FOR IsPrimaryKey ===
-            CAST(CASE 
+            cc.is_persisted AS IsPersisted,CAST(CASE 
                 WHEN EXISTS (
                     SELECT 1
                     FROM sys.index_columns ic
@@ -85,17 +82,12 @@ public class SourceDbTableService
                 ) THEN 1
                 ELSE 0
             END AS BIT) AS IsPrimaryKey
-
         FROM sys.tables t 
         INNER JOIN sys.schemas s ON t.schema_id = s.schema_id 
         INNER JOIN sys.columns c ON t.object_id = c.object_id 
         INNER JOIN sys.types ty ON c.user_type_id = ty.user_type_id 
         LEFT JOIN sys.default_constraints dc ON c.default_object_id = dc.object_id
-        LEFT JOIN sys.computed_columns cc ON c.object_id = cc.object_id AND c.column_id = cc.column_id
-        
-        -- === THE DUPLICATE-CAUSING JOINS HAVE BEEN REMOVED ===
-        
-        WHERE t.is_ms_shipped = 0 
+        LEFT JOIN sys.computed_columns cc ON c.object_id = cc.object_id AND c.column_id = cc.column_idWHERE t.is_ms_shipped = 0 
         ORDER BY s.name, t.name, c.column_id;";
 
         using IDbConnection conn = new SqlConnection(config.SourceConnectionString);


### PR DESCRIPTION
The decimal data generator had code that generated date for the money data type. Since money can handle larger types, it broke decimal/numeric sometimes.
Code removed.
I tidied up the SQL query and removed some needless comments and spaces.