### PR TITLE
Added precision and scale to the table creation script

### DIFF
--- a/Kopi.Core/Services/SQLServer/Target/ScriptCreationService.cs
+++ b/Kopi.Core/Services/SQLServer/Target/ScriptCreationService.cs
@@ -77,6 +77,11 @@ public static class ScriptCreationService
                 {
                     dataType += column.MaxLength == "-1" ? "(MAX)" : $"({column.MaxLength})";
                 }
+                else if (column.DataType.Equals("decimal", StringComparison.OrdinalIgnoreCase) ||
+                         column.DataType.Equals("numeric", StringComparison.OrdinalIgnoreCase))
+                {
+                    dataType += $"({column.NumericPrecision}, {column.NumericScale})";
+                }
 
                 columnDefinitions.Add($"    [{column.ColumnName}] {dataType} {nullability}");
             }


### PR DESCRIPTION
This is the second fix to the numeric data type issue.

Added precision and scale to the table creation script code so that it doesn't resort to defaults.