### PR TITLE
General error cleanup: updated the error handling

### DIFF
--- a/Kopi.Core/Services/Docker/DockerService.cs
+++ b/Kopi.Core/Services/Docker/DockerService.cs
@@ -250,11 +250,22 @@ public class DockerService
         var allContainersStatus = new List<ContainerStatusModel>();
 
 		_client ??= CreateNewDockerClient();
-		IList<ContainerListResponse> containers = await _client.Containers.ListContainersAsync(
-			new ContainersListParameters()
-			{
-				All = true
-			});
+
+        IList<ContainerListResponse> containers = null;
+
+        try
+        {
+            containers = await _client.Containers.ListContainersAsync(
+                new ContainersListParameters()
+                {
+                    All = true
+                });
+        }
+        catch (Exception ex)
+        {
+            Msg.Write(MessageType.Error, $"Error connecting to Docker daemon: {ex.Message}");
+            Environment.Exit(1);
+        }
 
 		foreach (var container in containers)
 		{


### PR DESCRIPTION
This will be part of an ongoing journey to add/fix error handling.

Added error handling so that the application doesn't crash when Docker isn't installed and you type "kopi status"